### PR TITLE
Rewrite EEPROM_Utils implementation

### DIFF
--- a/src/utils/EEPROM_Utils.cpp
+++ b/src/utils/EEPROM_Utils.cpp
@@ -117,14 +117,18 @@ namespace EEPROM_Utils {
 
       for (uint8_t i = 2; i > idx; --i) {
 
+        const size_t previousIndex = (i - 1);
+        const size_t sourceBaseIndex = (previousIndex * NAME_LENGTH_PLUS_TERM);
+        const size_t destinationBaseIndex = (i * NAME_LENGTH_PLUS_TERM);
+
         for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; ++j) {
 
-          const uint8_t x = eeprom_read_byte(&eepromHSName1[((i - 1) * NAME_LENGTH_PLUS_TERM) + j]);
-          eeprom_update_byte(&eepromHSName1[(i * NAME_LENGTH_PLUS_TERM) + j], x);
+          const uint8_t x = eeprom_read_byte(&eepromHSName1[sourceBaseIndex + j]);
+          eeprom_update_byte(&eepromHSName1[destinationBaseIndex + j], x);
 
         }
 
-        const uint16_t score = eeprom_read_word(&eepromHSScore1[i - 1]);
+        const uint16_t score = eeprom_read_word(&eepromHSScore1[previousIndex]);
         eeprom_update_word(&eepromHSScore1[i], score);
 
       }

--- a/src/utils/EEPROM_Utils.cpp
+++ b/src/utils/EEPROM_Utils.cpp
@@ -87,13 +87,8 @@ namespace EEPROM_Utils {
 
   }
 
+  static uint8_t testScore(uint16_t newScore) {
 
-  /* -----------------------------------------------------------------------------
-   *   Save score if it is in the top 3, return slot number (or NO_WINNER) ..
-   */
-  uint8_t saveScore(uint16_t newScore) {
-
-    uint8_t idx = NO_WINNER;
     uint16_t * const eepromHSScore1 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_1);
 
     for (uint8_t i = 0; i < 3; ++i) {
@@ -108,43 +103,56 @@ namespace EEPROM_Utils {
 
     }
 
+    return NO_WINNER;
+  
+  }
+
+  /* -----------------------------------------------------------------------------
+   *   Save score if it is in the top 3, return slot number (or NO_WINNER) ..
+   */
+  uint8_t saveScore(uint16_t newScore) {
+
+    uint8_t idx = testScore(newScore);
+
+    if(idx == NO_WINNER) {
+
+      return NO_WINNER;
+
+    }
 
     // New High Score ..
 
+    uint16_t * const eepromHSScore1 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_1);
     uint8_t * const eepromHSName1 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_1);
 
-    if (idx < NO_WINNER) {
+    for (uint8_t i = 2; i > idx; --i) {
 
-      for (uint8_t i = 2; i > idx; --i) {
+      const size_t previousIndex = (i - 1);
+      const size_t sourceBaseIndex = (previousIndex * NAME_LENGTH_PLUS_TERM);
+      const size_t destinationBaseIndex = (i * NAME_LENGTH_PLUS_TERM);
 
-        const size_t previousIndex = (i - 1);
-        const size_t sourceBaseIndex = (previousIndex * NAME_LENGTH_PLUS_TERM);
-        const size_t destinationBaseIndex = (i * NAME_LENGTH_PLUS_TERM);
+      for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; ++j) {
 
-        for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; ++j) {
-
-          const uint8_t x = eeprom_read_byte(&eepromHSName1[sourceBaseIndex + j]);
-          eeprom_update_byte(&eepromHSName1[destinationBaseIndex + j], x);
-
-        }
-
-        const uint16_t score = eeprom_read_word(&eepromHSScore1[previousIndex]);
-        eeprom_update_word(&eepromHSScore1[i], score);
+        const uint8_t x = eeprom_read_byte(&eepromHSName1[sourceBaseIndex + j]);
+        eeprom_update_byte(&eepromHSName1[destinationBaseIndex + j], x);
 
       }
 
-
-      // Write out new name and score ..
-
-      for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; j++) {
-
-        eeprom_update_byte(&eepromHSName1[(idx * NAME_LENGTH_PLUS_TERM) + j], '?');
-
-      }
-
-      eeprom_write_word(&eepromHSScore1[idx], newScore);
+      const uint16_t score = eeprom_read_word(&eepromHSScore1[previousIndex]);
+      eeprom_update_word(&eepromHSScore1[i], score);
 
     }
+
+
+    // Write out new name and score ..
+
+    for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; j++) {
+
+      eeprom_update_byte(&eepromHSName1[(idx * NAME_LENGTH_PLUS_TERM) + j], '?');
+
+    }
+
+    eeprom_write_word(&eepromHSScore1[idx], newScore);
 
     return idx;
 

--- a/src/utils/EEPROM_Utils.cpp
+++ b/src/utils/EEPROM_Utils.cpp
@@ -19,13 +19,13 @@ namespace EEPROM_Utils {
 
   void initEEPROM(bool forceClear) {
 
-    uint8_t * eepromStartChar1 = reinterpret_cast<uint8_t *>(EEPROM_START_C1);
-    uint8_t * eepromStartChar2 = reinterpret_cast<uint8_t *>(EEPROM_START_C2);
+    uint8_t * const eepromStartChar1 = reinterpret_cast<uint8_t *>(EEPROM_START_C1);
+    uint8_t * const eepromStartChar2 = reinterpret_cast<uint8_t *>(EEPROM_START_C2);
 
-    uint8_t * eepromHSName1 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_1);
-    uint8_t * eepromHSName2 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_2);
-    uint8_t * eepromHSName3 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_3);
-    uint8_t * eepromEnd = reinterpret_cast<uint8_t *>(EEPROM_END);
+    uint8_t * const eepromHSName1 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_1);
+    uint8_t * const eepromHSName2 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_2);
+    uint8_t * const eepromHSName3 = reinterpret_cast<uint8_t *>(EEPROM_HS_NAME_3);
+    uint8_t * const eepromEnd = reinterpret_cast<uint8_t *>(EEPROM_END);
 
     const byte c1 = eeprom_read_byte(eepromStartChar1);
     const byte c2 = eeprom_read_byte(eepromStartChar2);
@@ -53,9 +53,9 @@ namespace EEPROM_Utils {
 
     }
 
-    uint16_t * eepromHSScore1 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_1);
-    uint16_t * eepromHSScore2 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_2);
-    uint16_t * eepromHSScore3 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_3);
+    uint16_t * const eepromHSScore1 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_1);
+    uint16_t * const eepromHSScore2 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_2);
+    uint16_t * const eepromHSScore3 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_3);
 
     eeprom_update_word(eepromHSScore1, 0);
     eeprom_update_word(eepromHSScore2, 0);
@@ -82,7 +82,7 @@ namespace EEPROM_Utils {
    */
   uint16_t getHighScore(uint8_t startLoc) {
 
-    const uint16_t * scoreAddresss = reinterpret_cast<const uint16_t *>(startLoc);
+    const uint16_t * const scoreAddresss = reinterpret_cast<const uint16_t *>(startLoc);
     return eeprom_read_word(scoreAddresss);
 
   }
@@ -94,7 +94,7 @@ namespace EEPROM_Utils {
   uint8_t saveScore(uint16_t newScore) {
 
     uint8_t idx = NO_WINNER;
-    uint16_t * const eepromHSScore1 = reinterpret_cast<const uint16_t *>(EEPROM_HS_SCORE_1);
+    uint16_t * const eepromHSScore1 = reinterpret_cast<uint16_t *>(EEPROM_HS_SCORE_1);
 
     for (uint8_t i = 0; i < 3; ++i) {
 

--- a/src/utils/EEPROM_Utils.h
+++ b/src/utils/EEPROM_Utils.h
@@ -3,17 +3,13 @@
 #include "Arduboy2Ext.h"
 #include "Enums.h"
 
-class EEPROM_Utils {
+namespace EEPROM_Utils {
 
-  public: 
-
-    EEPROM_Utils(){};
-        
-    static void initEEPROM(bool forceClear);
-    static void getName(char *name, uint8_t startLoc);
-    static int16_t getHighScore(uint8_t startLoc);
-    static uint8_t saveScore(int16_t score);
-    static void saveChar(int8_t slotIdx, uint8_t charIdx, uint8_t newChar);
+  void initEEPROM(bool forceClear);
+  void getName(char (&name)[NAME_LENGTH + 1], uint8_t startLoc);
+  uint16_t getHighScore(uint8_t startLoc);
+  uint8_t saveScore(uint16_t score);
+  void saveChar(int8_t slotIdx, uint8_t charIdx, uint8_t newChar);
 
 };
 


### PR DESCRIPTION
~A very big change that should save \~492 bytes of progmem if it works.~
After the major bug fix, this only saves ~372 bytes of progmem.
PR #16 saves more so this should probably be closed in favour of #16.

**This is untested. Please test before merging.**