### PR TITLE
Add SaveEntry struct

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -34,7 +34,7 @@ void Game::setup(void) {
 	arduboy.setFrameRate(75);
 
 
-  EEPROM_Utils::initEEPROM(false);
+	EEPROM_Utils::initialiseEEPROM();
 
 	this->currentState = GameStateType::SplashScreen; 
 	this->splashScreenState.activate(*this);

--- a/src/states/HighScoreState.cpp
+++ b/src/states/HighScoreState.cpp
@@ -177,10 +177,11 @@ void HighScoreState::render(StateMachine & machine) {
 
 
   // Render scores ..
+  for (uint8_t index = 0; index < eepromSaveEntriesCount; ++index) {
 
-  renderHighScore(HS_CHAR_TOP, this->players[0]);
-  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING, this->players[1]);
-  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING + HS_CHAR_V_SPACING, this->players[2]);
+    renderHighScore(HS_CHAR_TOP + (HS_CHAR_V_SPACING * index), this->players[index]);
+
+  }
 
 
   // Render edit field if the slot is being editted ..

--- a/src/states/HighScoreState.cpp
+++ b/src/states/HighScoreState.cpp
@@ -18,16 +18,8 @@ void HighScoreState::activate(StateMachine & machine) {
 
   arduboy.clearButtonState();
 
-
   // Retrieve existing names and scores ..
-
-  EEPROM_Utils::getName(this->player1, EEPROM_HS_NAME_1);
-  EEPROM_Utils::getName(this->player2, EEPROM_HS_NAME_2);
-  EEPROM_Utils::getName(this->player3, EEPROM_HS_NAME_3);
-
-  this->score1 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_1);
-  this->score2 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_2);
-  this->score3 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_3);
+  EEPROM_Utils::readSaveEntries(this->players);
 
 }
 
@@ -50,7 +42,7 @@ void HighScoreState::update(StateMachine & machine) {
 
       if (pressed & UP_BUTTON) {
 
-        char *player = this->players[this->winnerIdx];
+        char *player = this->players[this->winnerIdx].name;
         player[this->charIdx]++;
         if (player[this->charIdx] > 90) player[this->charIdx] = 65;
         if (player[this->charIdx] == 64) player[this->charIdx] = 65;
@@ -59,7 +51,7 @@ void HighScoreState::update(StateMachine & machine) {
 
       if (pressed & DOWN_BUTTON) {
 
-        char *player = this->players[this->winnerIdx];
+        char *player = this->players[this->winnerIdx].name;
         player[this->charIdx]--;
         if (player[this->charIdx] < 65) player[this->charIdx] = 90;
         if (player[this->charIdx] == 62) player[this->charIdx] = 90;
@@ -76,7 +68,7 @@ void HighScoreState::update(StateMachine & machine) {
 
       if (pressed & A_BUTTON) {
 
-        char *player = this->players[this->winnerIdx];
+        char *player = this->players[this->winnerIdx].name;
 
         if (player[0] != 63 && player[1] != 63 && player[2] != 63) {
           
@@ -124,15 +116,8 @@ void HighScoreState::update(StateMachine & machine) {
 
 				clearScores = 0;
 				arduboy.setRGBled(0, 0, 0);
-				EEPROM_Utils::initEEPROM(true);
-
-				EEPROM_Utils::getName(this->player1, EEPROM_HS_NAME_1);
-				EEPROM_Utils::getName(this->player2, EEPROM_HS_NAME_2);
-				EEPROM_Utils::getName(this->player3, EEPROM_HS_NAME_3);
-
-				this->score1 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_1);
-				this->score2 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_2);
-				this->score3 = EEPROM_Utils::getHighScore(EEPROM_HS_SCORE_3);
+				EEPROM_Utils::clearEEPROM();
+				EEPROM_Utils::readSaveEntries(this->players);
 
 				break;
 
@@ -158,16 +143,16 @@ void HighScoreState::update(StateMachine & machine) {
 }
 
 
-void HighScoreState::renderHighScore(uint8_t y, uint8_t chars[], int16_t score) {
+void HighScoreState::renderHighScore(uint8_t y, const SaveEntry & saveEntry) {
 
   for (uint8_t i = 0; i < 3; i++) {
-    SpritesB::drawOverwrite(HS_NAME_LEFT + (i * 6), y, font_images, chars[i] == 63 ? 0 : chars[i] - 64);
+    SpritesB::drawOverwrite(HS_NAME_LEFT + (i * 6), y, font_images, saveEntry.name[i] == 63 ? 0 : saveEntry.name[i] - 64);
   }
 
   for (uint8_t j = 6, x2 = HS_SCORE_LEFT - 4; j > 0; --j, x2 += 5) {
     
     uint8_t digits[6] = {};
-    extractDigits(digits, static_cast<uint16_t>(absT(score)));
+    extractDigits(digits, saveEntry.score);
     SpritesB::drawOverwrite(x2, y, font_images, digits[j - 1] + 27);
 
   }
@@ -193,16 +178,16 @@ void HighScoreState::render(StateMachine & machine) {
 
   // Render scores ..
 
-  renderHighScore(HS_CHAR_TOP, this->player1, this->score1);
-  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING, this->player2, this->score2);
-  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING + HS_CHAR_V_SPACING, this->player3, this->score3);
+  renderHighScore(HS_CHAR_TOP, this->players[0]);
+  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING, this->players[1]);
+  renderHighScore(HS_CHAR_TOP + HS_CHAR_V_SPACING + HS_CHAR_V_SPACING, this->players[2]);
 
 
   // Render edit field if the slot is being editted ..
 
   if (this->winnerIdx < NO_WINNER && flash) {
 
-    char *player = this->players[this->winnerIdx];
+    char *player = this->players[this->winnerIdx].name;
 
     arduboy.fillRect(HS_NAME_LEFT + (this->charIdx * 6) - 1, HS_CHAR_TOP + (winnerIdx * HS_CHAR_V_SPACING) - 1, 6, 8, WHITE);
     SpritesB::drawErase(HS_NAME_LEFT + (this->charIdx * 6), HS_CHAR_TOP + (HS_CHAR_V_SPACING * this->winnerIdx), font_images, player[this->charIdx] == 63 ? 0 : player[this->charIdx] - 64);

--- a/src/states/HighScoreState.h
+++ b/src/states/HighScoreState.h
@@ -3,6 +3,7 @@
 #include "../utils/GameContext.h"
 #include "../utils/GameState.h"
 #include "../utils/Enums.h"
+#include "../utils/SaveEntry.h"
 #include "../images/Images.h"
 #include "BaseState.h"
 
@@ -15,17 +16,9 @@ class HighScoreState : public BaseState {
     uint8_t clearScores = 0;
     uint8_t pressACounter = HS_PRESS_A_DELAY;
 
-    char player1[NAME_LENGTH + 1];
-    char player2[NAME_LENGTH + 1];
-    char player3[NAME_LENGTH + 1];
+	SaveEntry players[eepromSaveEntriesCount];
 
-    char * players[3] = { player1, player2, player3 };
-
-    int16_t score1;
-    int16_t score2;
-    int16_t score3;
-
-    void renderHighScore(uint8_t y, uint8_t chars[], int16_t score);
+    void renderHighScore(uint8_t y, const SaveEntry & saveEntry);
 
   public:	
   

--- a/src/utils/EEPROM_Utils.cpp
+++ b/src/utils/EEPROM_Utils.cpp
@@ -2,6 +2,8 @@
 #include "Arduboy2Ext.h"
 #include "Enums.h"
 
+#include <avr/eeprom.h>
+
 /* ----------------------------------------------------------------------------
  *   Is the EEPROM initialised?
  *
@@ -10,140 +12,157 @@
  *   it resets the settings ..
  */
 
-const char chars1[4] = { 'A', 'A', 'A', ' ' };
-const char chars2[4] = { 'B', 'B', 'B', ' ' };
-const char chars3[4] = { 'C', 'C', 'C', ' ' };
+constexpr uint8_t letter1 = 'F';
+constexpr uint8_t letter2 = 'P';
 
-const uint8_t letter1 = 'F'; 
-const uint8_t letter2 = 'P'; 
+namespace EEPROM_Utils {
 
-void EEPROM_Utils::initEEPROM(bool forceClear) {
+  void initialiseEEPROM() {
 
-  byte c1 = EEPROM.read(EEPROM_START_C1);
-  byte c2 = EEPROM.read(EEPROM_START_C2);
+    uint8_t * const eepromStartChar1 = reinterpret_cast<uint8_t *>(EEPROM_START_C1);
+    uint8_t * const eepromStartChar2 = reinterpret_cast<uint8_t *>(EEPROM_START_C2);
 
-  if (forceClear || c1 != letter1 || c2 != letter2) { 
+    const byte c1 = eeprom_read_byte(eepromStartChar1);
+    const byte c2 = eeprom_read_byte(eepromStartChar2);
 
-    EEPROM.update(EEPROM_START_C1, letter1);
-    EEPROM.update(EEPROM_START_C2, letter2);
+    if ((c1 != letter1) || (c2 != letter2)) {
 
-    for (uint8_t x = EEPROM_HS_NAME_1; x <= EEPROM_END; x++) {
-
-       EEPROM.update(x, 0);
+      clearEEPROM();
 
     }
-
-    for (uint8_t x = 0; x < 3; x++) {
-
-      EEPROM.update(EEPROM_HS_NAME_1 + x, chars1[x]);
-      EEPROM.update(EEPROM_HS_NAME_2 + x, chars2[x]);
-      EEPROM.update(EEPROM_HS_NAME_3 + x, chars3[x]);
-
-    }
-
-    int16_t score = 0;
-    EEPROM.put(EEPROM_HS_SCORE_1, score);
-    EEPROM.put(EEPROM_HS_SCORE_2, score);
-    EEPROM.put(EEPROM_HS_SCORE_3, score);
 
   }
 
-}
+  void clearEEPROM() {
 
+    uint8_t * const eepromStartChar1 = reinterpret_cast<uint8_t *>(EEPROM_START_C1);
+    uint8_t * const eepromStartChar2 = reinterpret_cast<uint8_t *>(EEPROM_START_C2);
 
-/* -----------------------------------------------------------------------------
- *   Get name ..
- */
-void EEPROM_Utils::getName(char *name, uint8_t startLoc) {
+    eeprom_update_byte(eepromStartChar1, letter1);
+    eeprom_update_byte(eepromStartChar2, letter2);
 
-  uint8_t chars[NAME_LENGTH + 1];
-
-  for (uint8_t x = 0; x < NAME_LENGTH; x++) {
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
     
-    chars[x] = EEPROM.read(startLoc + x);
+    for(uint8_t saveIndex = 0; saveIndex < eepromSaveEntriesCount; ++saveIndex) {
+    
+      SaveEntry entry { 0, "" };
 
-  }
+      for (uint8_t index = 0; index < SaveEntry::nameCount; ++index) {
 
-  chars[NAME_LENGTH] = 0;
+        entry.name[index] = ('A' + index);
+      
+      }
 
-  memcpy(name, &chars, NAME_LENGTH + 1);
+      entry.name[NAME_LENGTH] = '\0';
 
-}
-
-
-/* -----------------------------------------------------------------------------
- *   Get name ..
- */
-int16_t EEPROM_Utils::getHighScore(uint8_t startLoc) {
-
-  int16_t score = 0;
-  EEPROM.get(startLoc, score);
-
-  return score;
-
-}
-
-
-/* -----------------------------------------------------------------------------
- *   Save score if it is in the top 3, return slot number (or NO_WINNER) .. 
- */
-static uint8_t EEPROM_Utils::saveScore(int16_t score) {
-
-  int16_t scores[3];
-  uint8_t idx = NO_WINNER;
-
-  for (uint8_t i = 0; i < 3; i++) {
-
-    scores[i] = getHighScore(EEPROM_HS_SCORE_1 + (i * 2));
-
-    if (score >= scores[i]) {
-
-      idx = i;
-      break;
+      eeprom_update_block(&entry, &saveEntries[saveIndex], sizeof(SaveEntry));
 
     }
 
   }
 
+  uint8_t findScore(uint16_t newScore) {
 
-  // New High Score ..
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
 
-  if (idx < NO_WINNER) {
+    for (uint8_t i = 0; i < eepromSaveEntriesCount; ++i) {
 
-    for (uint8_t i = 2; i > idx; i--) {
+      const uint16_t oldScore = eeprom_read_word(&saveEntries[i].score);
 
-      for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; j++) {
+      if (newScore >= oldScore) {
 
-        uint8_t x = EEPROM.read(EEPROM_HS_NAME_1 + ((i - 1) * NAME_LENGTH_PLUS_TERM) + j);
-        EEPROM.update(EEPROM_HS_NAME_1 + (i * NAME_LENGTH_PLUS_TERM) + j, x);
+        return i;
 
       }
 
-      int16_t score = 0;
-      EEPROM.get(EEPROM_HS_SCORE_1 + ((i -1) * 2), score);
-      EEPROM.put(EEPROM_HS_SCORE_1 + (i * 2), score);
-
     }
 
-
-    // Write out new name and score ..
-
-    for (uint8_t j = 0; j < NAME_LENGTH_PLUS_TERM; j++) {
-
-      EEPROM.update(EEPROM_HS_NAME_1 + (idx * NAME_LENGTH_PLUS_TERM) + j, '?');
-
-    }
-
-    EEPROM.put(EEPROM_HS_SCORE_1 + (idx * 2), score);
+    return NO_WINNER;
 
   }
 
-  return idx;
+  /* -----------------------------------------------------------------------------
+   *   Save score if it is in the top 3, return slot number (or NO_WINNER) ..
+   */
+  uint8_t saveScore(uint16_t newScore) {
 
-}
+    const uint8_t targetIndex = findScore(newScore);
 
-static void EEPROM_Utils::saveChar(int8_t slotIdx, uint8_t charIdx, uint8_t newChar) {
+    if(targetIndex == NO_WINNER) {
 
-  EEPROM.update(EEPROM_HS_NAME_1 + (slotIdx * NAME_LENGTH_PLUS_TERM) + charIdx, newChar);
+      return NO_WINNER;
 
+    }
+
+    // New High Score ..
+
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
+
+    for (uint8_t index = (eepromSaveEntriesCount - 1); index > targetIndex; --index) {
+
+      const uint8_t previousIndex = (index - 1);
+
+      SaveEntry entry;
+      eeprom_read_block(&entry, &saveEntries[previousIndex], sizeof(SaveEntry));
+      eeprom_update_block(&entry, &saveEntries[index], sizeof(SaveEntry));
+
+    }
+
+    // Save new name and score ..
+    SaveEntry entry { newScore, { '?', '?', '?', '\0' } };
+    eeprom_update_block(&entry, &saveEntries[targetIndex], sizeof(SaveEntry));
+
+    return targetIndex;
+
+  }
+
+  void saveChar(uint8_t saveIndex, uint8_t charIndex, char newChar) {
+
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
+    uint8_t * const bytePointer = reinterpret_cast<uint8_t *>(&saveEntries[saveIndex].name[charIndex]);
+    eeprom_update_byte(bytePointer, newChar);
+
+  }
+
+  void readSaveEntry(SaveEntry & entry, uint8_t saveIndex) {
+
+    const SaveEntry * const saveEntries = reinterpret_cast<const SaveEntry *>(eepromSaveEntriesStart);
+    eeprom_read_block(&entry, &saveEntries[saveIndex], sizeof(SaveEntry));
+
+  }
+
+  void readSaveEntryName(char (&name)[SaveEntry::nameSize], uint8_t saveIndex) {
+
+    const SaveEntry * const saveEntries = reinterpret_cast<const SaveEntry *>(eepromSaveEntriesStart);
+    eeprom_read_block(&name, &saveEntries[saveIndex].name, SaveEntry::nameSize);
+
+  }
+
+  uint16_t readSaveEntryScore(uint8_t saveIndex) {
+
+    const SaveEntry * const saveEntries = reinterpret_cast<const SaveEntry *>(eepromSaveEntriesStart);
+    return eeprom_read_word(&saveEntries[saveIndex].score);
+
+  }
+
+  void writeSaveEntry(const SaveEntry & entry, uint8_t saveIndex) {
+
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
+    eeprom_update_block(&entry, &saveEntries[saveIndex], sizeof(SaveEntry));
+
+  }
+
+  void writeSaveEntryName(const char (&name)[SaveEntry::nameSize], uint8_t saveIndex) {
+
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
+    eeprom_update_block(&name, &saveEntries[saveIndex].name, SaveEntry::nameSize);
+
+  }
+
+  void writeSaveEntryScore(uint16_t score, uint8_t saveIndex) {
+
+    SaveEntry * const saveEntries = reinterpret_cast<SaveEntry *>(eepromSaveEntriesStart);
+    eeprom_update_word(&saveEntries[saveIndex].score, score);
+
+  }
 }

--- a/src/utils/EEPROM_Utils.h
+++ b/src/utils/EEPROM_Utils.h
@@ -2,18 +2,30 @@
 
 #include "Arduboy2Ext.h"
 #include "Enums.h"
+#include "SaveEntry.h"
 
-class EEPROM_Utils {
+namespace EEPROM_Utils {
 
-  public: 
+  void initialiseEEPROM();
+  void clearEEPROM();
 
-    EEPROM_Utils(){};
-        
-    static void initEEPROM(bool forceClear);
-    static void getName(char *name, uint8_t startLoc);
-    static int16_t getHighScore(uint8_t startLoc);
-    static uint8_t saveScore(int16_t score);
-    static void saveChar(int8_t slotIdx, uint8_t charIdx, uint8_t newChar);
-
+  uint8_t saveScore(uint16_t score);
+  void saveChar(uint8_t saveIndex, uint8_t charIdx, char newChar);
+  
+  void readSaveEntry(SaveEntry & entry, uint8_t saveIndex);
+  void readSaveEntryName(char (&name)[SaveEntry::nameSize], uint8_t saveIndex);
+  uint16_t readSaveEntryScore(uint8_t saveIndex);
+  
+  void writeSaveEntry(const SaveEntry & entry, uint8_t saveIndex);
+  void writeSaveEntryName(const char (&name)[SaveEntry::nameSize], uint8_t saveIndex);
+  void writeSaveEntryScore(uint16_t score, uint8_t saveIndex);
+  
+  template< size_t size >
+  void readSaveEntries(SaveEntry (&entries)[size])
+  {
+    constexpr size_t count = (size <= eepromSaveEntriesCount) ? size : eepromSaveEntriesCount;
+    for(size_t index = 0; index < count; ++index)
+      readSaveEntry(entries[index], index);
+  }
 };
 

--- a/src/utils/Enums.h
+++ b/src/utils/Enums.h
@@ -110,6 +110,8 @@
 #define EEPROM_HS_SCORE_2             117
 #define EEPROM_HS_SCORE_3             119
 #define EEPROM_END                    121
+constexpr size_t eepromSaveEntriesCount = 3;
+constexpr size_t eepromSaveEntriesStart = 103;
 
 #define FLASH_FRAME_COUNT_2 56
 #define CAR_COLLISION_NONE 255

--- a/src/utils/SaveEntry.h
+++ b/src/utils/SaveEntry.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// For uint16_t
+#include <stdint.h>
+
+// For size_t
+#include <stddef.h>
+
+#include "Enums.h"
+
+struct SaveEntry
+{
+	static constexpr size_t nameSize = NAME_LENGTH_PLUS_TERM;
+	static constexpr size_t nameCount = (nameSize - 1);
+
+	uint16_t score;
+	char name[nameSize];
+};


### PR DESCRIPTION
Saves a combined total of ~478 bytes of progmem and ~6 bytes of RAM.
The resulting code is also much easier to read and understand.

It's still untested, but I'm more confident that it will work because there's less room for error when copying entire structs instead of dealing with bits and pieces.

This saves more memory than #15, so #15 should probably be closed in favour of this PR.