### PR TITLE
Reduce code size through static context members

### DIFF
--- a/FirePanic/src/utils/GameContext.cpp
+++ b/FirePanic/src/utils/GameContext.cpp
@@ -19,6 +19,9 @@
 #include "GameContext.h"
 #include "Utils.h"
 
+Arduboy2Ext GameContext::arduboy;
+ArduboyTonesExt GameContext::sound;
+
 GameContext::GameContext() { }
 
 void GameContext::resetGame() {

--- a/FirePanic/src/utils/GameContext.h
+++ b/FirePanic/src/utils/GameContext.h
@@ -28,8 +28,8 @@ class GameContext {
 
     GameStateType gameState;
     GameStateType nextState;
-    Arduboy2Ext arduboy;
-    ArduboyTonesExt sound;
+    static Arduboy2Ext arduboy;
+    static ArduboyTonesExt sound;
     GameStats gameStats;
 
     GameContext();


### PR DESCRIPTION
Make Arduboy2Ext and ArduboyTonesExt static members of GameContext.  Since these are only ever used in a global sense, this simplifies the code since it can do direct access to these instead of doing offset references from passed in pointers.  On Arduino 1.8.13, code size went from 26672 bytes to 26564, while global size dropped one byte from 1385 to 1384.